### PR TITLE
Refactor flake.nix and generate vault approles on the fly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,22 +69,6 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600853454,
-        "narHash": "sha256-EgsgbcJNZ9AQLVhjhfiegGjLbO+StBY9hfKsCwc8Hw8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "94cf59784c73ecec461eaa291918eff0bfb538ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1604964167,
@@ -97,37 +81,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1601282935,
-        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1594969032,
-        "narHash": "sha256-nbZfz02QoVe1yYK7EtCV7wMi4VdHzZEoPg20ZSDo9to=",
-        "owner": "hercules-ci",
-        "repo": "gitignore",
-        "rev": "c4662e662462e7bf3c2a968483478a665d00e717",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore",
         "type": "github"
       }
     },
@@ -147,29 +100,6 @@
         "type": "github"
       }
     },
-    "hermetic": {
-      "inputs": {
-        "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_2",
-        "gitignore": "gitignore",
-        "mix-to-nix": "mix-to-nix",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1602170269,
-        "narHash": "sha256-/+5VlgS+HBmJs2kdZiVMHJ3/cqHsxB42E13j76haWDQ=",
-        "owner": "serokell",
-        "repo": "hermetic",
-        "rev": "3eac6c490630d14180af6556accef10ba534e9b5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "ref": "flake",
-        "repo": "hermetic",
-        "type": "github"
-      }
-    },
     "lowdown-src": {
       "flake": false,
       "locked": {
@@ -183,23 +113,6 @@
       "original": {
         "owner": "kristapsdz",
         "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "mix-to-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1582143122,
-        "narHash": "sha256-bTDz1rGzdq0Bjer2EOC6OamSml7Wb3djaD7AMUhldVI=",
-        "owner": "serokell",
-        "repo": "mix-to-nix",
-        "rev": "b5f210e5c6f489c820608327a046727bf86f467b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "ref": "transumption",
-        "repo": "mix-to-nix",
         "type": "github"
       }
     },
@@ -227,7 +140,7 @@
     "nix-unstable": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1605199519,
@@ -276,20 +189,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1602126357,
-        "narHash": "sha256-9CVubBIrWzdWZCVVa0uF5OHls19r5gZz3qMeEAJPowQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8aeaba64d757e5cc626ac525f7504308de83741f",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1602702596,
         "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
         "owner": "NixOS",
@@ -303,7 +202,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1590126174,
         "narHash": "sha256-OLBpG2HW80zoQ8O0Z2+ZnSML6/gILwEVUMM8XZP3/vk=",
@@ -318,23 +217,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1598385881,
-        "narHash": "sha256-kBvSrVo9NrWlQEvMtjEx/TCEDQTAG1M8pxhyxj0PSyU=",
-        "owner": "serokell",
-        "repo": "nixpkgs",
-        "rev": "66a26e65eb7f9b6cb3f773052da0cd3ac52f015c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1601640588,
         "narHash": "sha256-EKCgoeOA5i3DQQx2lfyzvjwCiklnSCXsnHzh9gg1AD4=",
@@ -359,40 +242,20 @@
         "upload-daemon": "upload-daemon"
       }
     },
-    "scratch": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_6"
-      },
-      "locked": {
-        "lastModified": 1598628702,
-        "narHash": "sha256-8qdXBvZRdIGyh4ffo2tkt1LpfkVXwNNiS4/G83x0oyM=",
-        "owner": "serokell",
-        "repo": "scratch",
-        "rev": "4eeea82cb6f7230d1707ec5d2b63686a0b349d5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "repo": "scratch",
-        "type": "github"
-      }
-    },
     "serokell-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils",
         "gitignore-nix": "gitignore-nix",
-        "hermetic": "hermetic",
         "nix-unstable": "nix-unstable",
-        "nixpkgs": "nixpkgs_5",
-        "scratch": "scratch"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1605529100,
-        "narHash": "sha256-jfEaw6jy0L9f8WXXZgyRgqEhNbeUwBdHapbxExR4E70=",
+        "lastModified": 1605877243,
+        "narHash": "sha256-mmhJShFOpwtmPasJluVjFKKG0Zu528OvY+IOLs520PM=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "2b920e2b4b5a9b9d8b6dac7a04c4430cbf5abc7e",
+        "rev": "88d8cd7526b7f26b8e4516ed5e7ad619b0e43185",
         "type": "github"
       },
       "original": {
@@ -419,7 +282,7 @@
     },
     "upload-daemon": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1605229303,


### PR DESCRIPTION
See serokell/serokell.nix#9

- Refactor `flake.nix` to reduce unnecessary complexity we get by supporting non-Linux
- Use vault-push-approles to generate and push approles to vault