### PR TITLE
[OPS-1132] Provide wasabi credentials to upload-daemon

### DIFF
--- a/servers/albali/upload-daemon.nix
+++ b/servers/albali/upload-daemon.nix
@@ -6,6 +6,9 @@ in
 {
   vault-secrets.secrets.nix.services = [];
 
+  # contains AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for wasabi
+  vault-secrets.secrets.upload-daemon = {};
+
   services.upload-daemon = {
     enable = true;
     target = cache;
@@ -15,4 +18,6 @@ in
       secretKey = "${vs.nix}/key";
     };
   };
+
+  systemd.services.upload-daemon.serviceConfig.EnvironmentFile = "${vs.upload-daemon}/environment";
 }


### PR DESCRIPTION
Make sure upload-daemon has credentials for uploading to wasabi.

PR for adding approle: https://github.com/serokell/serokell-profiles/pull/577