### PR TITLE
[TM-511] Update edo protocol in local-chain services

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -301,11 +301,11 @@
     "tezos-packaging": {
       "flake": false,
       "locked": {
-        "lastModified": 1607935961,
-        "narHash": "sha256-3Z5qnA614RBZMLWtRzOLtDz1VXddCI85ldmE8B3WelI=",
+        "lastModified": 1613143624,
+        "narHash": "sha256-crxKN8tENu+TlkdlTblCKwvoozJqip4R3K0PJc//EXg=",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "b2b3687c9d89ac00fb134ea6015fd970aa7a39d9",
+        "rev": "931fb679500c707a756e5471bf991eafc686adfe",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -273,6 +273,7 @@
         "nixpkgs": "nixpkgs_3",
         "serokell-nix": "serokell-nix",
         "tezos-packaging": "tezos-packaging",
+        "tezos-packaging-v8_1-1": "tezos-packaging-v8_1-1",
         "upload-daemon": "upload-daemon"
       }
     },
@@ -310,6 +311,23 @@
       },
       "original": {
         "owner": "serokell",
+        "repo": "tezos-packaging",
+        "type": "github"
+      }
+    },
+    "tezos-packaging-v8_1-1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1610442216,
+        "narHash": "sha256-pKUp3gHFm7pc37DSJqaGzwTmD+SZ4WuntJ3fDzxkKGc=",
+        "owner": "serokell",
+        "repo": "tezos-packaging",
+        "rev": "8bd7371ed13640e66477991c095dd5d0ea9f9b27",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "ref": "v8.1-1",
         "repo": "tezos-packaging",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,13 @@
       url = "github:serokell/tezos-packaging";
       flake = false;
     };
+    # At the moment we need two versions of Tezos binaries, because
+    # backward compatibility was broken in v8.2. This hack should be
+    # removed once https://issues.serokell.io/issue/TM-511 is resolved.
+    tezos-packaging-v8_1-1 = {
+      url = "github:serokell/tezos-packaging/v8.1-1";
+      flake = false;
+    };
     nix-master.url = "github:nixos/nix";
   };
 

--- a/servers/albali/chain.nix
+++ b/servers/albali/chain.nix
@@ -38,7 +38,7 @@
   };
   services.local-chains.chains.edonet = {
     rpcPort = 8734;
-    baseProtocol = "008-PtEdoTez";
+    baseProtocol = "008-PtEdo2Zk";
     moneybagSecretKeys =
       config.services.local-chains.chains.delphinet.moneybagSecretKeys;
   };

--- a/servers/albali/chain.nix
+++ b/servers/albali/chain.nix
@@ -36,8 +36,14 @@
       "unencrypted:edsk2pSdHRGcASgMdieWEKMnsA36vexLDJtJEfnv2AHVD8Fv1TQoD6"
     ];
   };
-  services.local-chains.chains.edonet = {
+  services.local-chains.chains.old-edonet = {
     rpcPort = 8734;
+    baseProtocol = "008-PtEdoTez";
+    moneybagSecretKeys =
+      config.services.local-chains.chains.delphinet.moneybagSecretKeys;
+  };
+  services.local-chains.chains.edonet = {
+    rpcPort = 8733;
     baseProtocol = "008-PtEdo2Zk";
     moneybagSecretKeys =
       config.services.local-chains.chains.delphinet.moneybagSecretKeys;

--- a/servers/albali/local-chain-tezos-node.nix
+++ b/servers/albali/local-chain-tezos-node.nix
@@ -21,11 +21,14 @@ let
   tezos-bakers = {
     "007-PsDELPH1" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-007-PsDELPH1}/bin/tezos-baker-007-PsDELPH1";
+    "008-PtEdoTez" =
+      "${pkgs-with-tezos.ocamlPackages.tezos-baker-008-PtEdoTez}/bin/tezos-baker-008-PtEdoTez";
     "008-PtEdo2Zk" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-008-PtEdo2Zk}/bin/tezos-baker-008-PtEdo2Zk";
   };
   full-protocols-names = {
     "007-PsDELPH1" = "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo";
+    "008-PtEdoTez" = "PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq";
     "008-PtEdo2Zk" = "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA";
   };
   nodeConfigs = {
@@ -46,6 +49,27 @@ let
           };
           incompatible_chain_name = "INCOMPATIBLE";
           old_chain_name = "TEZOS_DELPHINET_2020-09-04T07:08:53Z";
+          sandboxed_chain_name = "SANDBOXED_TEZOS";
+        };
+        p2p = { };
+      };
+    "008-PtEdoTez" = genesisPubkey:
+      { network = {
+          chain_name = "TEZOS_EDONET_2020-11-30T12:00:00Z";
+          default_bootstrap_peers = [ ];
+          genesis = {
+            block = "BLockGenesisGenesisGenesisGenesisGenesis2431bbUwV2a";
+            protocol = "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex";
+            timestamp = "2020-09-04T07:08:53Z";
+          };
+          genesis_parameters = {
+            values = {
+              genesis_pubkey =
+                genesisPubkey;
+            };
+          };
+          incompatible_chain_name = "INCOMPATIBLE";
+          old_chain_name = "TEZOS_EDONET_2020-11-30T12:00:00Z";
           sandboxed_chain_name = "SANDBOXED_TEZOS";
         };
         p2p = { };

--- a/servers/albali/local-chain-tezos-node.nix
+++ b/servers/albali/local-chain-tezos-node.nix
@@ -19,40 +19,16 @@ let
     "${pkgs-with-tezos.ocamlPackages.tezos-client}/bin/tezos-client";
   tezos-node = "${pkgs-with-tezos.ocamlPackages.tezos-node}/bin/tezos-node";
   tezos-bakers = {
-    "006-PsCARTHA" =
-      "${pkgs-with-tezos.ocamlPackages.tezos-baker-006-PsCARTHA}/bin/tezos-baker-006-PsCARTHA";
     "007-PsDELPH1" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-007-PsDELPH1}/bin/tezos-baker-007-PsDELPH1";
     "008-PtEdo2Zk" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-008-PtEdo2Zk}/bin/tezos-baker-008-PtEdo2Zk";
   };
   full-protocols-names = {
-    "006-PsCARTHA" = "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb";
     "007-PsDELPH1" = "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo";
     "008-PtEdo2Zk" = "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA";
   };
   nodeConfigs = {
-    "006-PsCARTHA" = genesisPubkey:
-      { network = {
-          chain_name = "TEZOS_ALPHANET_CARTHAGE_2019-11-28T13:02:13Z";
-          default_bootstrap_peers = [ ];
-          genesis = {
-            block = "BLockGenesisGenesisGenesisGenesisGenesisd6f5afWyME7";
-            protocol = "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex";
-            timestamp = "2019-11-28T13:02:13Z";
-          };
-          genesis_parameters = {
-            values = {
-              genesis_pubkey =
-                genesisPubkey;
-            };
-          };
-          incompatible_chain_name = "INCOMPATIBLE";
-          old_chain_name = "TEZOS_ALPHANET_CARTHAGE_2019-11-28T13:02:13Z";
-          sandboxed_chain_name = "SANDBOXED_TEZOS";
-        };
-        p2p = { };
-      };
     "007-PsDELPH1" = genesisPubkey:
       { network = {
           chain_name = "TEZOS_DELPHINET_2020-09-04T07:08:53Z";
@@ -201,8 +177,8 @@ let
       baseProtocol = mkOption {
         type = types.str;
         description =
-          "Base protocol for local-chain, only '006-PsCARTHA' and '007-PsDELPH1' are supported";
-        example = "006-PsCARTHA";
+          "Base protocol for local-chain, only '007-PsDELPH1' and '008-PtEdo2Zk' are supported";
+        example = "008-PtEdo2Zk";
       };
     };
   });

--- a/servers/albali/local-chain-tezos-node.nix
+++ b/servers/albali/local-chain-tezos-node.nix
@@ -23,13 +23,13 @@ let
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-006-PsCARTHA}/bin/tezos-baker-006-PsCARTHA";
     "007-PsDELPH1" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-007-PsDELPH1}/bin/tezos-baker-007-PsDELPH1";
-    "008-PtEdoTez" =
-      "${pkgs-with-tezos.ocamlPackages.tezos-baker-008-PtEdoTez}/bin/tezos-baker-008-PtEdoTez";
+    "008-PtEdo2Zk" =
+      "${pkgs-with-tezos.ocamlPackages.tezos-baker-008-PtEdo2Zk}/bin/tezos-baker-008-PtEdo2Zk";
   };
   full-protocols-names = {
     "006-PsCARTHA" = "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb";
     "007-PsDELPH1" = "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo";
-    "008-PtEdoTez" = "PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq";
+    "008-PtEdo2Zk" = "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA";
   };
   nodeConfigs = {
     "006-PsCARTHA" = genesisPubkey:
@@ -74,14 +74,14 @@ let
         };
         p2p = { };
       };
-    "008-PtEdoTez" = genesisPubkey:
+    "008-PtEdo2Zk" = genesisPubkey:
       { network = {
           chain_name = "TEZOS_EDONET_2020-11-30T12:00:00Z";
           default_bootstrap_peers = [ ];
           genesis = {
-            block = "BLockGenesisGenesisGenesisGenesisGenesis2431bbUwV2a";
+            block = "BLockGenesisGenesisGenesisGenesisGenesisdae8bZxCCxh";
             protocol = "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex";
-            timestamp = "2020-09-04T07:08:53Z";
+            timestamp = "2021-02-11T14:00:00Z";
           };
           genesis_parameters = {
             values = {
@@ -90,7 +90,7 @@ let
             };
           };
           incompatible_chain_name = "INCOMPATIBLE";
-          old_chain_name = "TEZOS_EDONET_2020-11-30T12:00:00Z";
+          old_chain_name = "TEZOS_EDO2NET_2021-02-11T14:00:00Z";
           sandboxed_chain_name = "SANDBOXED_TEZOS";
         };
         p2p = { };


### PR DESCRIPTION
Problem: 008 Protocol was recently updated. We should run our tests
against the updated protocol.

Solution: Use '008-PtEdo2Zk' instead of '008-PtEdoTez' everywhere.

Related issue:
https://issues.serokell.io/issue/TM-511