### PR TITLE
[TM-511] Remove old-edo local-chain

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -273,7 +273,6 @@
         "nixpkgs": "nixpkgs_3",
         "serokell-nix": "serokell-nix",
         "tezos-packaging": "tezos-packaging",
-        "tezos-packaging-v8_1-1": "tezos-packaging-v8_1-1",
         "upload-daemon": "upload-daemon"
       }
     },
@@ -311,23 +310,6 @@
       },
       "original": {
         "owner": "serokell",
-        "repo": "tezos-packaging",
-        "type": "github"
-      }
-    },
-    "tezos-packaging-v8_1-1": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1610442216,
-        "narHash": "sha256-pKUp3gHFm7pc37DSJqaGzwTmD+SZ4WuntJ3fDzxkKGc=",
-        "owner": "serokell",
-        "repo": "tezos-packaging",
-        "rev": "8bd7371ed13640e66477991c095dd5d0ea9f9b27",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "ref": "v8.1-1",
         "repo": "tezos-packaging",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,13 +14,6 @@
       url = "github:serokell/tezos-packaging";
       flake = false;
     };
-    # At the moment we need two versions of Tezos binaries, because
-    # backward compatibility was broken in v8.2. This hack should be
-    # removed once https://issues.serokell.io/issue/TM-511 is resolved.
-    tezos-packaging-v8_1-1 = {
-      url = "github:serokell/tezos-packaging/v8.1-1";
-      flake = false;
-    };
     nix-master.url = "github:nixos/nix";
   };
 

--- a/servers/albali/chain.nix
+++ b/servers/albali/chain.nix
@@ -36,12 +36,6 @@
       "unencrypted:edsk2pSdHRGcASgMdieWEKMnsA36vexLDJtJEfnv2AHVD8Fv1TQoD6"
     ];
   };
-  services.local-chains.chains.old-edonet = {
-    rpcPort = 8734;
-    baseProtocol = "008-PtEdoTez";
-    moneybagSecretKeys =
-      config.services.local-chains.chains.delphinet.moneybagSecretKeys;
-  };
   services.local-chains.chains.edonet = {
     rpcPort = 8733;
     baseProtocol = "008-PtEdo2Zk";

--- a/servers/albali/local-chain-tezos-node.nix
+++ b/servers/albali/local-chain-tezos-node.nix
@@ -15,18 +15,14 @@ let
      }
     ));
   pkgs-with-tezos = (import "${inputs.tezos-packaging}/nix/build/pkgs.nix" { });
-  pkgs-with-tezos-v8_1 = (import "${inputs.tezos-packaging-v8_1-1}/nix/build/pkgs.nix" { });
   tezos-bakers = {
     "007-PsDELPH1" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-007-PsDELPH1}/bin/tezos-baker-007-PsDELPH1";
-    "008-PtEdoTez" =
-      "${pkgs-with-tezos-v8_1.ocamlPackages.tezos-baker-008-PtEdoTez}/bin/tezos-baker-008-PtEdoTez";
     "008-PtEdo2Zk" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-008-PtEdo2Zk}/bin/tezos-baker-008-PtEdo2Zk";
   };
   full-protocols-names = {
     "007-PsDELPH1" = "PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo";
-    "008-PtEdoTez" = "PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq";
     "008-PtEdo2Zk" = "PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA";
   };
   nodeConfigs = {
@@ -47,27 +43,6 @@ let
           };
           incompatible_chain_name = "INCOMPATIBLE";
           old_chain_name = "TEZOS_DELPHINET_2020-09-04T07:08:53Z";
-          sandboxed_chain_name = "SANDBOXED_TEZOS";
-        };
-        p2p = { };
-      };
-    "008-PtEdoTez" = genesisPubkey:
-      { network = {
-          chain_name = "TEZOS_EDONET_2020-11-30T12:00:00Z";
-          default_bootstrap_peers = [ ];
-          genesis = {
-            block = "BLockGenesisGenesisGenesisGenesisGenesis2431bbUwV2a";
-            protocol = "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex";
-            timestamp = "2020-09-04T07:08:53Z";
-          };
-          genesis_parameters = {
-            values = {
-              genesis_pubkey =
-                genesisPubkey;
-            };
-          };
-          incompatible_chain_name = "INCOMPATIBLE";
-          old_chain_name = "TEZOS_EDONET_2020-11-30T12:00:00Z";
           sandboxed_chain_name = "SANDBOXED_TEZOS";
         };
         p2p = { };
@@ -220,16 +195,8 @@ in {
     }));
     systemd = lib.mkMerge (flip mapAttrsToList cfg.chains (chain-name: chain-config:
       let
-        tezos-client =
-          if chain-config.baseProtocol == "008-PtEdoTez"
-          # v8.2 doesn't support old edo protocol
-          then "${pkgs-with-tezos-v8_1.ocamlPackages.tezos-client}/bin/tezos-client"
-          else "${pkgs-with-tezos.ocamlPackages.tezos-client}/bin/tezos-client";
-        tezos-node =
-          if chain-config.baseProtocol == "008-PtEdoTez"
-          # v8.2 doesn't support old edo protocol
-          then "${pkgs-with-tezos-v8_1.ocamlPackages.tezos-node}/bin/tezos-node"
-          else "${pkgs-with-tezos.ocamlPackages.tezos-node}/bin/tezos-node";
+        tezos-client = "${pkgs-with-tezos.ocamlPackages.tezos-client}/bin/tezos-client";
+        tezos-node = "${pkgs-with-tezos.ocamlPackages.tezos-node}/bin/tezos-node";
       in {
       services."local-chain-${chain-name}-tezos-baker" = rec {
         wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
Problem: We wanted to have both old and new edo protocols based
local-chains at the same time to avoid massive CI failure during
switching from old to a new one.

Solution: We've switched all our projects, now we no longer need old-edo
local-chain.

Related issue:
https://issues.serokell.io/issue/TM-511