### PR TITLE
[OPS-1140] Add backblaze cache for nix builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,6 +84,21 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1610051610,
+        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitignore-nix": {
       "flake": false,
       "locked": {
@@ -316,14 +331,15 @@
     },
     "upload-daemon": {
       "inputs": {
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1610960413,
-        "narHash": "sha256-GM94iFRW/BDhOKlydRki+GKMgYCFertKuNAZYM3yeZ4=",
+        "lastModified": 1611677181,
+        "narHash": "sha256-fmXWQxPeXybcLz7pEcL1JYfRh2cYOu1rUR40+8OvVVI=",
         "owner": "serokell",
         "repo": "upload-daemon",
-        "rev": "eeb766a6a9f651448ba6f65fd3ec2c11947472cb",
+        "rev": "4dcace9fe332ec5f42c9d4ec621e9a44db0008bf",
         "type": "github"
       },
       "original": {

--- a/servers/albali/upload-daemon.nix
+++ b/servers/albali/upload-daemon.nix
@@ -1,17 +1,39 @@
 { config, pkgs, lib, ...}:
 let
   vs = config.vault-secrets.secrets;
-  cache = "s3://serokell-private-cache?endpoint=s3.eu-central-1.wasabisys.com&narinfo-compression=bzip2&compression=xz&parallel-compression=1";
+
+  credentialsTemplate = pkgs.writeText "credentials-template" ''
+    [wasabi]
+    aws_access_key_id=$WASABI_ACCESS_KEY_ID
+    aws_secret_access_key=$WABASI_SECRET_ACCESS_KEY
+
+    [backblaze]
+    aws_access_key_id=$BACKBLAZE_ACCESS_KEY_ID
+    aws_secret_access_key=$BACKBLAZE_SECRET_ACCESS_KEY
+  '';
+
 in
 {
+  nix.binaryCaches = [
+    "s3://serokell-private-nix-cache?endpoint=s3.us-west-000.backblazeb2.com&profile=backblaze-cache-read"
+  ];
+
   vault-secrets.secrets.nix.services = [];
 
-  # contains AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for wasabi
-  vault-secrets.secrets.upload-daemon = {};
+  vault-secrets.secrets.upload-daemon.extraScript = ''
+    source "$secretsPath/environment"
+    export $(cut -d= -f1 "$secretsPath/environment")
+    ${pkgs.envsubst}/bin/envsubst -no-unset -i ${credentialsTemplate} -o $secretsPath/aws_credentials
+  '';
 
   services.upload-daemon = {
     enable = true;
-    target = cache;
+    targets =
+      let commonOptions = "&narinfo-compression=bzip2&compression=xz&parallel-compression=1";
+      in [
+        "s3://serokell-private-cache?endpoint=s3.eu-central-1.wasabisys.com&profile=wasabi${commonOptions}"
+        "s3://serokell-private-nix-cache?endpoint=s3.us-west-000.backblazeb2.com&profile=backblaze${commonOptions}"
+      ];
     prometheusPort = 8082;
     post-build-hook = {
       enable = true;
@@ -19,5 +41,7 @@ in
     };
   };
 
-  systemd.services.upload-daemon.serviceConfig.EnvironmentFile = "${vs.upload-daemon}/environment";
+  systemd.services.upload-daemon.serviceConfig.Environment = [
+    "AWS_SHARED_CREDENTIALS_FILE=${vs.upload-daemon}/aws_credentials"
+  ];
 }


### PR DESCRIPTION
Sets up backblaze b2 bucket as a cache for all builds, in addition to wasabi.

I've noticed that to configure nix to use it as a substituter we also have to update `/root/.aws/credentials` file manually. It might be good to take these credentials from vault somehow.