### PR TITLE
albali: Add aarch64 emulated system

### DIFF
--- a/servers/albali/builders.nix
+++ b/servers/albali/builders.nix
@@ -10,5 +10,7 @@
     }];
   };
 
+  boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+
   vault-secrets.secrets.mac-builder = { services = [ "nix-daemon" ]; };
 }


### PR DESCRIPTION
Add a qemu exec format for aarch64 and make Nix support it as a builder. This means we can now build or check `aarch64-linux` derivations natively.