### PR TITLE
[OPS-1062] Limit number of upload-daemon workers and compress with bzip2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -335,11 +335,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1611677181,
-        "narHash": "sha256-fmXWQxPeXybcLz7pEcL1JYfRh2cYOu1rUR40+8OvVVI=",
+        "lastModified": 1615448040,
+        "narHash": "sha256-dlI/YQ8JQXQ/FyJ9sypfaDoDFipwtbNV1yZ5ucztNMY=",
         "owner": "serokell",
         "repo": "upload-daemon",
-        "rev": "4dcace9fe332ec5f42c9d4ec621e9a44db0008bf",
+        "rev": "3cc3520fe9535443463c8a1d16f595c253ef4725",
         "type": "github"
       },
       "original": {

--- a/servers/albali/upload-daemon.nix
+++ b/servers/albali/upload-daemon.nix
@@ -29,7 +29,7 @@ in
   services.upload-daemon = {
     enable = true;
     targets =
-      let commonOptions = "&narinfo-compression=bzip2&compression=xz&parallel-compression=1";
+      let commonOptions = "&narinfo-compression=bzip2&compression=bzip2";
       in [
         "s3://serokell-private-cache?endpoint=s3.eu-central-1.wasabisys.com&profile=wasabi${commonOptions}"
         "s3://serokell-private-nix-cache?endpoint=s3.us-west-000.backblazeb2.com&profile=backblaze${commonOptions}"
@@ -39,6 +39,9 @@ in
       enable = true;
       secretKey = "${vs.nix}/key";
     };
+
+    # set number of concurrent uploads to the number of targets
+    workers = lib.length config.services.upload-daemon.targets;
   };
 
   systemd.services.upload-daemon.serviceConfig.Environment = [


### PR DESCRIPTION
Several 'nix copy' processes can start uploading the same path simultaneously and overuse CPU, and enabling parallel compression makes 'nix copy' take up all CPU cores. So limiting CPU usage for upload-daemon sounds good, to keep more resources for the CI builds