### PR TITLE
Increase nix-gc threshold on albali to 300GB

### DIFF
--- a/servers/albali/default.nix
+++ b/servers/albali/default.nix
@@ -16,6 +16,8 @@
     ./gitlab.nix
   ];
 
+  # run nix-gc to keep at least 300GB free
+  nix.gc.keep-gb = 300;
 
   # Use GRUB2 as the boot loader.
   # We don't use systemd-boot because Hetzner uses BIOS legacy boot.


### PR DESCRIPTION
By default serokell.nix sets it to 15GB, but for albali we can afford to keep more space available