### PR TITLE
[LIGO-141] Don't run untagged jobs for gitlab.com/serokell group

### DIFF
--- a/common/gitlab.nix
+++ b/common/gitlab.nix
@@ -5,6 +5,7 @@ in {
   shellRunner = registrationTokenFile: extraConfig: (recursiveUpdate {
     executor = "shell";
     tagList = [ "shell-executor" "nix" ];
+    # some of our pipelines don't set any tag
     runUntagged = true;
 
     registrationConfigFile = pkgs.writeText "gitlab-registration.sh" ''

--- a/servers/albali/gitlab.nix
+++ b/servers/albali/gitlab.nix
@@ -12,7 +12,9 @@ in rec {
       morley-shell = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_MORLEY_SHELL" {};
 
       # https://gitlab.com/serokell
-      shell = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_SHELL" {};
+      shell = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_SHELL" {
+        runUntagged = false;
+      };
 
       # https://gitlab.com/tezosagora
       agora-shell = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_AGORA_SHELL" {};


### PR DESCRIPTION
Running untagged jobs on our agents causes problems for projects we fork (ligo in particular), because they expect untagged jobs to run on a shared runner with docker.

There are two active pipelines in the `serokell` group, tezos-nbit and ligo, and they both specify a tag for jobs which need to run on our agent, so this change won't break CI for them. It would be good to disable `runUntagged` for other agents too, but some pipelines in other groups depend on it