### PR TITLE
[OPS-1138] Expose node-exporter metrics via wireguard

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -5,6 +5,8 @@ in {
     inputs.serokell-nix.nixosModules.common
     inputs.serokell-nix.nixosModules.serokell-users
     inputs.vault-secrets.nixosModules.vault-secrets
+
+    ./common/monitoring.nix
   ];
 
   networking.domain = "${constellation}.serokell.team";

--- a/common/monitoring.nix
+++ b/common/monitoring.nix
@@ -1,0 +1,42 @@
+{ config, pkgs, lib, ... }:
+
+let
+  wireguard-ip = config.wireguard-ip-address;
+
+in {
+  options.wireguard-ip-address = lib.mkOption {
+    type = lib.types.str;
+    description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
+    example = "172.21.0.3";
+  };
+
+  config = {
+    networking.firewall.allowedUDPPorts = [
+      51820 # wireguard
+    ];
+
+    # enable wireguard
+    networking.wireguard.interfaces.wg0 = {
+      listenPort = 51820;
+      ips = [ "${wireguard-ip}/16" ];
+
+      # generate private key if it does not exist
+      # (you can also generate it manually with `wg genkey > private_key`)
+      generatePrivateKeyFile = true;
+      privateKeyFile = "/etc/wireguard/secret";
+
+      # set up link to polis
+      peers = [{
+        allowedIPs = [ "172.21.0.1/32" ];
+        endpoint = "polis.sagittarius.serokell.team:51820";
+        publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
+      }];
+    };
+
+    # run node-exporter on the wireguard interface
+    services.prometheus.exporters.node.listenAddress = wireguard-ip;
+
+    # wait for wireguard before starting node-exporter
+    systemd.services.prometheus-node-exporter.after = [ "wireguard-wg0.service" ];
+  };
+}

--- a/servers/albali/default.nix
+++ b/servers/albali/default.nix
@@ -29,6 +29,7 @@
   };
 
   networking.hostName = "albali";
+  wireguard-ip-address = "172.21.0.2";
 
   # The mdadm RAID1s were created with 'mdadm --create ... --homehost=hetzner',
   # but the hostname for each machine may be different, and mdadm's HOMEHOST

--- a/servers/bunda/default.nix
+++ b/servers/bunda/default.nix
@@ -6,7 +6,9 @@
   ];
 
   boot.cleanTmpDir = true;
+
   networking.hostName = "bunda";
+  wireguard-ip-address = "172.21.0.3";
 
   hetzner.ipv6Address = "2a01:4f8:1c17:74fb::1";
 


### PR DESCRIPTION
See PR for prometheus: https://github.com/serokell/sagittarius-infra/pull/12