### PR TITLE
[OPS-1138] Set up firewall rules for exporting metrics via wireguard

### DIFF
--- a/common/monitoring.nix
+++ b/common/monitoring.nix
@@ -15,6 +15,11 @@ in {
       51820 # wireguard
     ];
 
+    # firewall rules for the wireguard interface
+    networking.firewall.interfaces.wg0.allowedTCPPorts = [
+      9100 # prometheus node exporter
+    ];
+
     # enable wireguard
     networking.wireguard.interfaces.wg0 = {
       listenPort = 51820;


### PR DESCRIPTION
All traffic on the wireguard interface is blocked by default, so we need to open ports explicitly