### PR TITLE
[EDNA-49] Albali: Enable container config for skopeo

### DIFF
--- a/servers/albali/default.nix
+++ b/servers/albali/default.nix
@@ -68,4 +68,8 @@
     interface = "enp35s0";
   };
   networking.nameservers = [ "8.8.8.8" ];
+
+  # Provide default configuration in '/etc/containers'
+  # Necessary for `skopeo copy`
+  virtualisation.containers.enable = true;
 }


### PR DESCRIPTION
Skopeo needs `/etc/containers/policy.json` to copy images to a registry. This
option provides it.

It does not actually enable Docker or any other container runtime.

Related: https://github.com/serokell/edna/pull/35