### PR TITLE
[LIGO-182] Add gitlab-runner for serokell project on bunda

### DIFF
--- a/servers/bunda/gitlab.nix
+++ b/servers/bunda/gitlab.nix
@@ -13,6 +13,12 @@ in rec {
         { runUntagged = false;
           tagList = [ "nix-with-docker" ];
         };
+
+      # https://gitlab.com/serokell
+      shell = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_SHELL"
+        { runUntagged = false;
+          tagList = [ "nix-with-docker" ];
+        };
     };
   };
 


### PR DESCRIPTION
We need gitlab-runner with docker for the ligo project, to build ligo executable