### PR TITLE
[TM-554] Add granadanet-based local-chain

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -413,11 +413,11 @@
     "tezos-packaging": {
       "flake": false,
       "locked": {
-        "lastModified": 1616419111,
-        "narHash": "sha256-54Mpd0T7P7+VZZlGjnut9wHbYZO7mpVnVK+lvpOWImw=",
+        "lastModified": 1623151099,
+        "narHash": "sha256-QqrY1exv0ntiCGDexn7TNMhjgmVCiOo92T3fU6tQR9k=",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "564ef19153d61719e3fcfb5160c3b18f9dcc2dee",
+        "rev": "6b58d2dae45dedeed127511c73f13a5d24363d31",
         "type": "github"
       },
       "original": {

--- a/servers/albali/chain.nix
+++ b/servers/albali/chain.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }: {
+{ config, lib, pkgs, options, ... }: {
   services.local-chains.chains.florencenet = {
     rpcPort = 8734;
     baseProtocol = "009-PsFLoren";
@@ -35,5 +35,12 @@
       # tz1fDbuARxQapX6yP6k8QAGRUichBABDSh9T
       "unencrypted:edsk2pSdHRGcASgMdieWEKMnsA36vexLDJtJEfnv2AHVD8Fv1TQoD6"
     ];
+  };
+  services.local-chains.chains.granadanet = {
+    rpcPort = 8733;
+    baseProtocol = "010-PtGRANAD";
+    moneybagSecretKeys = config.services.local-chains.chains.florencenet.moneybagSecretKeys;
+    # Since 010 there is a new constant to define minimal delay between blocks
+    chainParameters = config.services.local-chains.chains.florencenet.chainParameters // { minimal_block_delay = "1"; };
   };
 }

--- a/servers/albali/local-chain-tezos-node.nix
+++ b/servers/albali/local-chain-tezos-node.nix
@@ -18,9 +18,12 @@ let
   tezos-bakers = {
     "009-PsFLoren" =
       "${pkgs-with-tezos.ocamlPackages.tezos-baker-009-PsFLoren}/bin/tezos-baker-009-PsFLoren";
+    "010-PtGRANAD" =
+      "${pkgs-with-tezos.ocamlPackages.tezos-baker-010-PtGRANAD}/bin/tezos-baker-010-PtGRANAD";
   };
   full-protocols-names = {
     "009-PsFLoren" = "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i";
+    "010-PtGRANAD" = "PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV";
   };
   nodeConfigs = {
     "009-PsFLoren" = genesisPubkey:
@@ -31,6 +34,26 @@ let
             block = "BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM";
             protocol = "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex";
             timestamp = "2021-03-04T20:00:00Z";
+          };
+          genesis_parameters = {
+            values = {
+              genesis_pubkey =
+                genesisPubkey;
+            };
+          };
+          incompatible_chain_name = "INCOMPATIBLE";
+          sandboxed_chain_name = "SANDBOXED_TEZOS";
+        };
+        p2p = { };
+      };
+    "010-PtGRANAD" = genesisPubkey:
+      { network = {
+          chain_name = "TEZOS_GRANADANET_2021-05-21T15:00:00Z";
+          default_bootstrap_peers = [ ];
+          genesis = {
+            block = "BMFCHw1mv3A71KpTuGD3MoFnkHk9wvTYjUzuR9QqiUumKGFG6pM";
+            protocol = "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex";
+            timestamp = "2021-05-21T15:00:00Z";
           };
           genesis_parameters = {
             values = {


### PR DESCRIPTION
Problem: A new Tezos protocol arrived and we need another one toy
blockchain with short block period to test our projects.

Solution: Add granadanet-based local-chain to albali, so that it's
possible to use it in CI.

Related issue: https://issues.serokell.io/issue/TM-554