### PR TITLE
[TM-554] Remove one old parameters constant

### DIFF
--- a/servers/albali/chain.nix
+++ b/servers/albali/chain.nix
@@ -35,13 +35,17 @@
       # tz1fDbuARxQapX6yP6k8QAGRUichBABDSh9T
       "unencrypted:edsk2pSdHRGcASgMdieWEKMnsA36vexLDJtJEfnv2AHVD8Fv1TQoD6"
     ];
+    # This constant is not expected in 010, so it's not in the default value
+    chainParameters = {
+      test_chain_duration = "1966080";
+    };
   };
   services.local-chains.chains.granadanet = {
     rpcPort = 8733;
     baseProtocol = "010-PtGRANAD";
     moneybagSecretKeys = config.services.local-chains.chains.florencenet.moneybagSecretKeys;
     # Since 010 there are a bunch of new constants
-    chainParameters = config.services.local-chains.chains.florencenet.chainParameters //
+    chainParameters =
       { minimal_block_delay = "1";
         liquidity_baking_escape_ema_threshold = 1000000;
         liquidity_baking_subsidy = "2500000";

--- a/servers/albali/local-chain-tezos-node.nix
+++ b/servers/albali/local-chain-tezos-node.nix
@@ -162,7 +162,6 @@ let
           quorum_max = 7000;
           quorum_min = 2000;
           seed_nonce_revelation_tip = "125000";
-          test_chain_duration = "1966080";
           time_between_blocks = [ "1" "2" ];
           tokens_per_roll = "8000000000";
         };


### PR DESCRIPTION
Because Tezos is very good at breaking backward compatibility.