### PR TITLE
Automatically update flake.lock to the latest version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1624612639,
-        "narHash": "sha256-tIZDdJahWg+zq1kbJZ7aoQp12Wr37w8soTm9Gg1CRoo=",
+        "lastModified": 1624914173,
+        "narHash": "sha256-7gRCSiJG0v0SI9SF9fjjm6ihViFoaoR5F7vBFYSkSOQ=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "bf68c693dc5157c2be1f3a9f407dd1ce3761df78",
+        "rev": "9feca5cdf64b82bfb06dfda07d19d007a2dfa1c1",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1622593737,
-        "narHash": "sha256-9loxFJg85AbzJrSkU4pE/divZ1+zOxDy2FSjlrufCB8=",
+        "lastModified": 1624862269,
+        "narHash": "sha256-JFcsh2+7QtfKdJFoPibLFPLgIW6Ycnv8Bts9a7RYme0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb8a5e54845012ed1375ffd5f317d2fdf434b20e",
+        "rev": "f77036342e2b690c61c97202bf48f2ce13acc022",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     "tezos-packaging": {
       "flake": false,
       "locked": {
-        "lastModified": 1624609298,
-        "narHash": "sha256-LZa02uyU7Thbgt+M7efIFxT3kKI4NIqFn+8viUiqyrY=",
+        "lastModified": 1624891728,
+        "narHash": "sha256-uml6vYsGhloKzfmMfK7aQ5H41bkJqMkKgqZ11WDQBQg=",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "3272f98d8f2981a0d181f76d58bc6ac5b97416fa",
+        "rev": "4ff573b6b9a07db9bfaa58d913ffa803947a0019",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1623011836,
-        "narHash": "sha256-02M4P3eqUdV+ouZb8n1KDR1CXeZQm17cKpjKZKi0c10=",
+        "lastModified": 1624477559,
+        "narHash": "sha256-5lxwWMhCc+y+oSmDO7b9LNy20o9b/V5OKO9XS7gLxzE=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "70d71b3027b1793b780f1e2435bdbbe1b0cb9ac6",
+        "rev": "0964acc95051bd2b2d3ea0c9ab691e7be6eda7c0",
         "type": "github"
       },
       "original": {
@@ -222,11 +222,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1624284737,
-        "narHash": "sha256-k8keQhzwutEqxuwBMI+TKOd1nk+nreWH0iU9ckWo+kU=",
+        "lastModified": 1624539732,
+        "narHash": "sha256-DI9lKhVx2KWcoU8UT7W9L++PY9aVXs4iLU+GweRplrU=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "610baf359ab61d2ed07e13d119d8340a37beead3",
+        "rev": "08270af7fec1ca9954274a747e39c0d45bdb963e",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     "tezos-packaging": {
       "flake": false,
       "locked": {
-        "lastModified": 1623418700,
-        "narHash": "sha256-eMG6KuFfTSivAz5EDTXA0Vm3TiuWtB0DFMxH9xDx334=",
+        "lastModified": 1624535179,
+        "narHash": "sha256-mlCXoXhYHyYCZIjpQNTy2CTp9ebbeiNI0CfekETnuvU=",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "2c56b7de345bf23e9f2312f2a69ecbd1ef2de8a5",
+        "rev": "107cd22e1fa923266b63bee3cc4dcccce57fd56b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1624539732,
-        "narHash": "sha256-DI9lKhVx2KWcoU8UT7W9L++PY9aVXs4iLU+GweRplrU=",
+        "lastModified": 1624612639,
+        "narHash": "sha256-tIZDdJahWg+zq1kbJZ7aoQp12Wr37w8soTm9Gg1CRoo=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "08270af7fec1ca9954274a747e39c0d45bdb963e",
+        "rev": "bf68c693dc5157c2be1f3a9f407dd1ce3761df78",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     "tezos-packaging": {
       "flake": false,
       "locked": {
-        "lastModified": 1624535179,
-        "narHash": "sha256-mlCXoXhYHyYCZIjpQNTy2CTp9ebbeiNI0CfekETnuvU=",
+        "lastModified": 1624609298,
+        "narHash": "sha256-LZa02uyU7Thbgt+M7efIFxT3kKI4NIqFn+8viUiqyrY=",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "107cd22e1fa923266b63bee3cc4dcccce57fd56b",
+        "rev": "3272f98d8f2981a0d181f76d58bc6ac5b97416fa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1624914173,
-        "narHash": "sha256-7gRCSiJG0v0SI9SF9fjjm6ihViFoaoR5F7vBFYSkSOQ=",
+        "lastModified": 1624972202,
+        "narHash": "sha256-2yV/wQ55cbnOaXOJonzCJdeoT+vE93+IN2TR/BZGGZQ=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "9feca5cdf64b82bfb06dfda07d19d007a2dfa1c1",
+        "rev": "c92fbdb654df15a658db857f0c025fa64e7092c9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1616406726,
-        "narHash": "sha256-n9zmgxR03QNrvs9/fHewqE0j3SjL7Y+cglBCFu3U3rg=",
+        "lastModified": 1623011836,
+        "narHash": "sha256-02M4P3eqUdV+ouZb8n1KDR1CXeZQm17cKpjKZKi0c10=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "9e405fbc5ab5bacbd271fd78c6b6b6877c4d9f8d",
+        "rev": "70d71b3027b1793b780f1e2435bdbbe1b0cb9ac6",
         "type": "github"
       },
       "original": {
@@ -149,6 +149,23 @@
     "lowdown-src": {
       "flake": false,
       "locked": {
+        "lastModified": 1617481909,
+        "narHash": "sha256-SqnfOFuLuVRRNeVJr1yeEPJue/qWoCp5N6o5Kr///p4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "148f9b2f586c41b7e36e73009db43ea68c7a1a4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "ref": "VERSION_0_8_4",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1598695561,
         "narHash": "sha256-gyH/5j+h/nWw0W8AcR2WKvNBUsiQ7QuxqSJNXAwV+8E=",
         "owner": "kristapsdz",
@@ -162,7 +179,7 @@
         "type": "github"
       }
     },
-    "lowdown-src_2": {
+    "lowdown-src_3": {
       "flake": false,
       "locked": {
         "lastModified": 1598695561,
@@ -185,11 +202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1610392286,
-        "narHash": "sha256-3wFl5y+4YZO4SgRYK8WE7JIS3p0sxbgrGaQ6RMw+d98=",
+        "lastModified": 1622810282,
+        "narHash": "sha256-4wmvM3/xfD0hCdNDIXVzRMfL4yB1J+DjH6Zte2xbAxk=",
         "owner": "nmattia",
         "repo": "naersk",
-        "rev": "d7bfbad3304fd768c0f93a4c3b50976275e6d4be",
+        "rev": "e8061169e1495871b56be97c5c51d310fae01374",
         "type": "github"
       },
       "original": {
@@ -201,14 +218,15 @@
     },
     "nix-master": {
       "inputs": {
+        "lowdown-src": "lowdown-src",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1612198108,
-        "narHash": "sha256-NqX1R27yI5RcTXzuN7iv1v5+HNh8skp9ICDuVqPYh9M=",
+        "lastModified": 1624284737,
+        "narHash": "sha256-k8keQhzwutEqxuwBMI+TKOd1nk+nreWH0iU9ckWo+kU=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "0e05cb6c619afca77f0162d8f2cc62d6618500de",
+        "rev": "610baf359ab61d2ed07e13d119d8340a37beead3",
         "type": "github"
       },
       "original": {
@@ -219,7 +237,7 @@
     },
     "nix-unstable": {
       "inputs": {
-        "lowdown-src": "lowdown-src",
+        "lowdown-src": "lowdown-src_2",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
@@ -238,7 +256,7 @@
     },
     "nix-unstable_2": {
       "inputs": {
-        "lowdown-src": "lowdown-src_2",
+        "lowdown-src": "lowdown-src_3",
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
@@ -257,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1610942247,
-        "narHash": "sha256-PKo1ATAlC6BmfYSRmX0TVmNoFbrec+A5OKcabGEu2yU=",
+        "lastModified": 1622972307,
+        "narHash": "sha256-ENOu0FPCf95iLLoq2txhJtnA2ZpOFhIVBqQVbKM8ra0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7d71001b796340b219d1bfa8552c81995017544a",
+        "rev": "d8eb97e3801bde96491535f40483d550b57605b9",
         "type": "github"
       },
       "original": {
@@ -273,16 +291,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1602702596,
-        "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
-        "owner": "nixos",
+        "lastModified": 1622593737,
+        "narHash": "sha256-9loxFJg85AbzJrSkU4pE/divZ1+zOxDy2FSjlrufCB8=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad0d20345219790533ebe06571f82ed6b034db31",
+        "rev": "bb8a5e54845012ed1375ffd5f317d2fdf434b20e",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-20.09-small",
+        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
@@ -397,11 +415,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1621844655,
-        "narHash": "sha256-LlXyUc7tNNmnWS/W0zz0OVtpSgEu1zBxp0TBPxNokdg=",
+        "lastModified": 1623202063,
+        "narHash": "sha256-2P4Yq35f+r7BEwnZJJELxy5bnExv+R7mBJlQsIdYb3o=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "42b192ca488df6e0ae5f4e3abbe99e615b632e55",
+        "rev": "0ce2e0c59cb698c25630d2140f896d70d664fe8b",
         "type": "github"
       },
       "original": {
@@ -413,11 +431,11 @@
     "tezos-packaging": {
       "flake": false,
       "locked": {
-        "lastModified": 1623151099,
-        "narHash": "sha256-QqrY1exv0ntiCGDexn7TNMhjgmVCiOo92T3fU6tQR9k=",
+        "lastModified": 1623418700,
+        "narHash": "sha256-eMG6KuFfTSivAz5EDTXA0Vm3TiuWtB0DFMxH9xDx334=",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "6b58d2dae45dedeed127511c73f13a5d24363d31",
+        "rev": "2c56b7de345bf23e9f2312f2a69ecbd1ef2de8a5",
         "type": "github"
       },
       "original": {
@@ -447,11 +465,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1610051610,
-        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "lastModified": 1622445595,
+        "narHash": "sha256-m+JRe6Wc5OZ/mKw2bB3+Tl0ZbtyxxxfnAWln8Q5qs+Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "rev": "7d706970d94bc5559077eb1a6600afddcd25a7c8",
         "type": "github"
       },
       "original": {
@@ -468,11 +486,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1619415603,
-        "narHash": "sha256-CkKmzwSAuRtYUzxbwz32V4bzhAXB8h6F3tJTkLCjg0w=",
+        "lastModified": 1624279110,
+        "narHash": "sha256-cb9QEY0u8xcuxXp4J2yx3zjOBsMbW+GMW7nTCggCbnE=",
         "owner": "serokell",
         "repo": "vault-secrets",
-        "rev": "0dfb5d38d23896c58b0df61bea9750b24e4ed8ed",
+        "rev": "4f51f7ba0e44abff546ea41997c91f2399d9f784",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1624972202,
-        "narHash": "sha256-2yV/wQ55cbnOaXOJonzCJdeoT+vE93+IN2TR/BZGGZQ=",
+        "lastModified": 1625068621,
+        "narHash": "sha256-bwN6rMVKp7fL/uGE2yb4cqyw3Z3tWM8R+faaG0bWQX0=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "c92fbdb654df15a658db857f0c025fa64e7092c9",
+        "rev": "139f7af5ec40ca75ad2ef9393c5029f0850105d9",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
     "tezos-packaging": {
       "flake": false,
       "locked": {
-        "lastModified": 1624891728,
-        "narHash": "sha256-uml6vYsGhloKzfmMfK7aQ5H41bkJqMkKgqZ11WDQBQg=",
+        "lastModified": 1625048617,
+        "narHash": "sha256-uLiX51S/2asnD2yxsQfEV7A7Q2MjMa4CS8JlgYOKEDI=",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "4ff573b6b9a07db9bfaa58d913ffa803947a0019",
+        "rev": "fa9445a767572908a6e422e856f18476c439b82c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| input | old | new | diff |
|-------|-----|-----|------|
| deploy-rs | `9e405fbc5a (2021-03-22)` | `0964acc950 (2021-06-23)` | [link](https://github.com/serokell/deploy-rs/compare/9e405fbc5ab5bacbd271fd78c6b6b6877c4d9f8d...0964acc95051bd2b2d3ea0c9ab691e7be6eda7c0?expand=1) |
| nix-master | `0e05cb6c61 (2021-02-01)` | `139f7af5ec (2021-06-30)` | [link](https://github.com/nixos/nix/compare/0e05cb6c619afca77f0162d8f2cc62d6618500de...139f7af5ec40ca75ad2ef9393c5029f0850105d9?expand=1) |
| serokell-nix | `42b192ca48 (2021-05-24)` | `0ce2e0c59c (2021-06-09)` | [link](https://github.com/serokell/serokell.nix/compare/42b192ca488df6e0ae5f4e3abbe99e615b632e55...0ce2e0c59cb698c25630d2140f896d70d664fe8b?expand=1) |
| tezos-packaging | `6b58d2dae4 (2021-06-08)` | `fa9445a767 (2021-06-30)` | [link](https://github.com/serokell/tezos-packaging/compare/6b58d2dae45dedeed127511c73f13a5d24363d31...fa9445a767572908a6e422e856f18476c439b82c?expand=1) |
| vault-secrets | `0dfb5d38d2 (2021-04-26)` | `4f51f7ba0e (2021-06-21)` | [link](https://github.com/serokell/vault-secrets/compare/0dfb5d38d23896c58b0df61bea9750b24e4ed8ed...4f51f7ba0e44abff546ea41997c91f2399d9f784?expand=1) |

CC @serokell/operations