### PR TITLE
[TM-547] Add gitlab agent for 'tezos-kiln'

### DIFF
--- a/servers/albali/gitlab.nix
+++ b/servers/albali/gitlab.nix
@@ -21,6 +21,9 @@ in rec {
 
       # https://gitlab.com/indigo-lang
       indigo-lang = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_INDIGO_LANG" {};
+
+      # https://gitlab.com/tezos-kiln
+      tezos-kiln = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_KILN_SHELL" {};
     };
   };
 


### PR DESCRIPTION
Problem: Some time ago we started maintaining Kiln project.
At the moment, it lacks any kind of CI which makes developers life
much harder.

Solution: Add a gitlab agent for 'tezos-kiln' group, so that it'll be
possible to setup CI using our infrastructure.

Related issue: https://issues.serokell.io/issue/TM-547.

~Unfortunately, I don't have token yet:(~