### PR TITLE
Increase gitlab-runner concurrency and number of nixbld users

### DIFF
--- a/servers/albali/gitlab.nix
+++ b/servers/albali/gitlab.nix
@@ -6,7 +6,7 @@ in rec {
   vault-secrets.secrets.gitlab-runner = { };
   services.gitlab-runner = {
     enable = true;
-    concurrent = 4;
+    concurrent = 10;
     services = {
       # https://gitlab.com/morley-framework
       morley-shell = gitlab.shellRunner "${vs.gitlab-runner}/REG_TOKEN_MORLEY_SHELL" {};

--- a/servers/albali/hardware-configuration.nix
+++ b/servers/albali/hardware-configuration.nix
@@ -19,7 +19,10 @@
 
   swapDevices = [ ];
 
-  nix.nrBuildUsers = 24;
+  # Make a lot of build users, because nix-build will fail when they are exhausted.
+  # There is a fix to wait for users to be available instead of failing, but it's not in stable yet:
+  # https://github.com/NixOS/nix/pull/3564
+  nix.nrBuildUsers = 128;
   nix.maxJobs = 8;
   powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
 }


### PR DESCRIPTION
Low concurrency underutilizes albali resources when there is only a
single pipeline running, but with high concurrency we can run into a
problem with nixbld users being taken up, so we increase the number of
nixbld users as well.